### PR TITLE
feat: disconnect market context from all pipelines

### DIFF
--- a/src/orchestration/digest-pipeline.ts
+++ b/src/orchestration/digest-pipeline.ts
@@ -1,8 +1,8 @@
 // src/orchestration/digest-pipeline.ts
 import { generateGoodNight } from '../content/summarize.js';
 import { logger } from '../utils/logger.js';
-import { collectMarketSnapshot } from '../market/market-snapshot.js';
 import { generateBatch } from '../content/batch-generator.js';
+import type { MarketSnapshot } from '../market/market-snapshot.js';
 import {
   enqueueMicroPosts,
   getNextUnposted,
@@ -16,20 +16,25 @@ import { xBudgetState, getUnusedHeadlines } from './state.js';
 import { withPipelineMetrics } from './helpers.js';
 import { publish, content } from '../delivery/publisher.js';
 
+function emptySnapshot(unusedHeadlines: string[] = []): MarketSnapshot {
+  return {
+    prices: [],
+    fearGreed: null,
+    unusedHeadlines,
+    marketMood: 'neutral',
+    timeOfDay: 'morning',
+    volatilityAlerts: [],
+  };
+}
+
 // ─── Morning Batches ──────────────────────────────────────────────────────────
 
 export async function runMorningBatches(): Promise<void> {
   logger.info('🎲 Starting morning batch generation...');
   try {
-    const snapshot = await collectMarketSnapshot();
-    const [vibePosts, philosophyPosts] = await Promise.all([
-      generateBatch('market_vibe', snapshot),
-      generateBatch('philosophy', snapshot),
-    ]);
-    logger.info(
-      `🎲 Morning batches ready — vibe: ${vibePosts.length}, philosophy: ${philosophyPosts.length}`,
-    );
-    await enqueueMicroPosts(vibePosts);
+    const stub = emptySnapshot();
+    const philosophyPosts = await generateBatch('philosophy', stub);
+    logger.info(`🎲 Morning batch ready — philosophy: ${philosophyPosts.length}`);
     await enqueueMicroPosts(philosophyPosts);
     const pending = await getPendingCount();
     logger.info(`📊 Queue size after morning batches: ${pending}`);
@@ -48,8 +53,8 @@ export async function runAfternoonBatch(): Promise<void> {
       logger.warn('⚠️ No unused headlines available, skipping raw_headlines batch');
       return;
     }
-    const snapshot = await collectMarketSnapshot(headlines);
-    const posts = await generateBatch('raw_headlines', snapshot);
+    const stub = emptySnapshot(headlines);
+    const posts = await generateBatch('raw_headlines', stub);
     logger.info(`🎲 Afternoon batch ready — raw_headlines: ${posts.length}`);
     await enqueueMicroPosts(posts);
     const pending = await getPendingCount();
@@ -69,8 +74,8 @@ export async function runDegenTime(): Promise<void> {
       logger.warn('⚠️ No unused headlines for DegenTime, skipping');
       return;
     }
-    const snapshot = await collectMarketSnapshot(headlines);
-    const posts = await generateBatch('degen_time', snapshot);
+    const stub = emptySnapshot(headlines);
+    const posts = await generateBatch('degen_time', stub);
     if (posts.length > 0) {
       await enqueueMicroPosts(posts);
       logger.info(`💊 DegenTime enqueued: ${posts[0]!.text}`);

--- a/src/orchestration/helpers.ts
+++ b/src/orchestration/helpers.ts
@@ -6,7 +6,6 @@ import { BLACKLIST } from '../utils/constants.js';
 import { type FeedArticle, fetchFeeds } from '../ingestion/rss.js';
 import { isDuplicate } from '../ingestion/dedup.js';
 import { filterSimilar } from '../ingestion/similarity.js';
-import { collectMarketSnapshot } from '../market/market-snapshot.js';
 import { scoreArticles, type ScoredArticle } from '../intelligence/scorer.js';
 import { getUnusedHeadlines } from './state.js';
 
@@ -96,9 +95,8 @@ export async function getFilteredScoredArticles(
 
   const fresh = withSimilarityFilter ? await filterSimilar(deduplicated) : deduplicated;
 
-  const snapshot = await collectMarketSnapshot();
   const recentTitles = withRecentTitles ? getUnusedHeadlines() : undefined;
-  const scored = scoreArticles(fresh, snapshot, recentTitles);
+  const scored = scoreArticles(fresh, undefined, recentTitles);
 
   return { scored, fresh, fetchedCount, filteredCount };
 }

--- a/src/orchestration/news-pipeline.ts
+++ b/src/orchestration/news-pipeline.ts
@@ -1,15 +1,11 @@
 // src/orchestration/news-pipeline.ts
 import { type FeedArticle } from '../ingestion/rss.js';
-import { fetchPrices, formatPricesPost, formatPricesPostX } from '../market/prices.js';
 import { saveArticle, markAsPosted } from '../ingestion/dedup.js';
 import { summarizeArticle } from '../content/summarize.js';
 import { formatPostTelegram, formatPostX } from '../content/format.js';
 import { logger } from '../utils/logger.js';
 import { rankArticles } from '../intelligence/ranker.js';
-import { fetchFearGreed } from '../market/feargreed.js';
 import { updateLastPosted } from '../health/server.js';
-import { postTweet } from '../delivery/twitter.js';
-import { sendToTelegram } from '../delivery/telegram.js';
 import { generatePostImage, type ImageSentiment } from '../images/generate-image.js';
 import { MAX_RANKER_INPUT } from '../utils/constants.js';
 import { geminiCircuit, getUnusedHeadlines, setUnusedHeadlines } from './state.js';
@@ -44,14 +40,6 @@ export async function runMorningDigest(): Promise<void> {
   logger.info('🌅 Starting morning digest...');
 
   await withPipelineMetrics('morning', async () => {
-    const [prices, fearGreed] = await Promise.all([fetchPrices(), fetchFearGreed()]);
-
-    const tgPost = formatPricesPost(prices, fearGreed);
-    const xPost = await formatPricesPostX(prices, fearGreed);
-
-    await sendToTelegram(tgPost);
-    await postTweet(xPost);
-
     await runNewsPipeline(1);
   });
 }

--- a/src/orchestration/scheduler.ts
+++ b/src/orchestration/scheduler.ts
@@ -9,7 +9,6 @@ import { logger } from '../utils/logger.js';
 import { TIMEZONE } from '../utils/constants.js';
 import { runMorningDigest, runNewsPipeline } from './news-pipeline.js';
 import { runMondayBriefing, runWeeklySummary } from './special-pipeline.js';
-import { invalidateSnapshotCache } from '../market/market-snapshot.js';
 // import { pollMentions, pollMonitoredTimelines, searchCryptoLatam } from '../social/x-monitor.js';
 // import { runMentionReplyPipeline } from '../social/mention-pipeline.js';
 
@@ -45,44 +44,14 @@ export function startScheduler(): void {
   // ─── Morning Digest — 08:00 daily ─────────────────────────────────────────
   // Fresh snapshot before posting, then digest + top article
 
-  cron.schedule(
-    '0 8 * * *',
-    async () => {
-      invalidateSnapshotCache();
-      await runMorningDigest();
-    },
-    { timezone: TIMEZONE },
-  );
+  cron.schedule('0 8 * * *', () => void runMorningDigest(), { timezone: TIMEZONE });
 
   // ─── Evening News — 19:00 / 20:00 / 21:00 daily ───────────────────────────
   // Fresh snapshot before each slot
 
-  cron.schedule(
-    '0 19 * * *',
-    async () => {
-      invalidateSnapshotCache();
-      await runNewsPipeline(1);
-    },
-    { timezone: TIMEZONE },
-  );
-
-  cron.schedule(
-    '0 20 * * *',
-    async () => {
-      invalidateSnapshotCache();
-      await runNewsPipeline(1);
-    },
-    { timezone: TIMEZONE },
-  );
-
-  cron.schedule(
-    '0 21 * * *',
-    async () => {
-      invalidateSnapshotCache();
-      await runNewsPipeline(1);
-    },
-    { timezone: TIMEZONE },
-  );
+  cron.schedule('0 19 * * *', () => void runNewsPipeline(1), { timezone: TIMEZONE });
+  cron.schedule('0 20 * * *', () => void runNewsPipeline(1), { timezone: TIMEZONE });
+  cron.schedule('0 21 * * *', () => void runNewsPipeline(1), { timezone: TIMEZONE });
 
   // ─── Weekly Summary — Saturday 21:00 ──────────────────────────────────────
   // Note: overrides evening news slot on Saturday — pipeline runs after summary

--- a/src/orchestration/special-pipeline.ts
+++ b/src/orchestration/special-pipeline.ts
@@ -1,8 +1,6 @@
 // src/orchestration/special-pipeline.ts
 import { saveArticle, markAsPosted } from '../ingestion/dedup.js';
 import { logger } from '../utils/logger.js';
-import { fetchFearGreed } from '../market/feargreed.js';
-import { fetchPrices, formatPricesPost } from '../market/prices.js';
 import { updateLastPosted } from '../health/server.js';
 import { db } from '../db/client.js';
 import { articles } from '../db/schema.js';
@@ -23,22 +21,17 @@ export async function runMondayBriefing(): Promise<void> {
   logger.info('🐸 Starting Monday briefing...');
 
   await withPipelineMetrics('monday', async () => {
-    const [prices, fearGreed, { scored }] = await Promise.all([
-      fetchPrices(),
-      fetchFearGreed(),
-      getFilteredScoredArticles({
-        withSimilarityFilter: false,
-        withRecentTitles: false,
-        withDedup: false,
-      }),
-    ]);
+    const { scored } = await getFilteredScoredArticles({
+      withSimilarityFilter: false,
+      withRecentTitles: false,
+      withDedup: false,
+    });
 
     const topHeadlines = scored.slice(0, 5).map((a) => a.title);
-    const pricesText = formatPricesPost(prices, fearGreed);
 
     const { text } = await generateText({
       model: getModel('weekly'),
-      prompt: buildMondayBriefingPrompt(pricesText, String(fearGreed?.value ?? '—'), topHeadlines),
+      prompt: buildMondayBriefingPrompt('', '', topHeadlines),
       experimental_telemetry: withToadEye({ functionId: 'monday-briefing' }),
     });
 
@@ -63,8 +56,6 @@ export async function runWeeklySummary(): Promise<void> {
   logger.info('🐸 Starting weekly summary...');
 
   await withPipelineMetrics('weekly', async () => {
-    const fearGreed = await fetchFearGreed();
-
     const since = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString();
     const weekArticles = await db
       .select({
@@ -89,13 +80,13 @@ export async function runWeeklySummary(): Promise<void> {
 
     const topArticles = weekArticles.map((a) => ({
       title: a.title,
-      category: a.category ?? 'trading',
+      category: a.category ?? 'industry',
       sentiment: a.sentiment ?? 'neutral',
     }));
 
     const { text } = await generateText({
       model: getModel('weekly'),
-      prompt: buildWeeklySummaryPrompt(topArticles, String(fearGreed?.value ?? '—'), weekNumber),
+      prompt: buildWeeklySummaryPrompt(topArticles, '', weekNumber),
       experimental_telemetry: withToadEye({ functionId: 'weekly-summary' }),
     });
 


### PR DESCRIPTION
## Summary

- Morning digest no longer posts crypto prices — just runs news pipeline
- Monday briefing and weekly summary no longer fetch prices/Fear&Greed
- Morning batches drop `market_vibe` type, keep `philosophy` + `raw_headlines`
- All pipelines use `emptySnapshot()` stub or no snapshot at all
- Remove `invalidateSnapshotCache` calls from scheduler
- Simplify cron handlers

## What's kept (dead code, for future use)

- `src/market/prices.ts` — fetchPrices, formatPricesPost
- `src/market/feargreed.ts` — fetchFearGreed
- `src/market/market-snapshot.ts` — collectMarketSnapshot
- `src/prompts/prices.prompt.ts` — MORNING_OPENERS, buildPricesHookPrompt

These will be repurposed for stock prices / AI Pulse later.

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)