### PR TITLE
test: add feed validation and verify all tests pass

### DIFF
--- a/src/__tests__/feeds-config.test.ts
+++ b/src/__tests__/feeds-config.test.ts
@@ -43,4 +43,26 @@ describe('feeds.config — smoke tests', () => {
     expect(found).toBeDefined();
     expect(found?.source).toBe(first.source);
   });
+
+  it('all feed URLs are valid', () => {
+    for (const feed of FEEDS) {
+      expect(() => new URL(feed.url)).not.toThrow();
+    }
+  });
+
+  it('no duplicate feed URLs', () => {
+    const urls = FEEDS.map((f) => f.url);
+    expect(new Set(urls).size).toBe(urls.length);
+  });
+
+  it('no duplicate source names', () => {
+    const sources = FEEDS.map((f) => f.source);
+    expect(new Set(sources).size).toBe(sources.length);
+  });
+
+  it('all feeds use English language', () => {
+    for (const feed of FEEDS) {
+      expect(feed.language).toBe('en');
+    }
+  });
 });


### PR DESCRIPTION
## Summary

- Add 4 new feed validation tests: valid URLs, no duplicate URLs, no duplicate sources, all English
- Verify all 55 tests pass after full crypto → AI migration
- typecheck ✅ lint ✅

Most test fixes were done in previous PRs (#9, #10). This PR adds the final validation layer.

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)